### PR TITLE
Fix overflow issue

### DIFF
--- a/crates/piet-glow/src/lib.rs
+++ b/crates/piet-glow/src/lib.rs
@@ -235,8 +235,12 @@ impl<H: HasContext + ?Sized> piet_hardware::GpuContext for GpuContext<H> {
             _ => panic!("unsupported image format: {format:?}"),
         };
 
-        let total_len = (width * height * data_width) as usize;
         if let Some(data) = data {
+            let total_len = usize::try_from(width)
+                .ok()
+                .and_then(|width| width.checked_mul(height.try_into().ok()?))
+                .and_then(|total| total.checked_mul(data_width.try_into().ok()?))
+                .expect("image data too large");
             assert_eq!(data.len(), total_len);
         }
 


### PR DESCRIPTION
Should close notgull/theo#1 by making it so the width/height/data_width are converted to `usize` before multiplying them.

@bitec0de Does this fix the issue that you observed?