### PR TITLE
Fix text layout handling

### DIFF
--- a/crates/piet-glow/examples/text.rs
+++ b/crates/piet-glow/examples/text.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later OR MPL-2.0
+// This file is a part of `piet-glow`.
+//
+// `piet-glow` is free software: you can redistribute it and/or modify it under the terms of
+// either:
+//
+// * GNU Lesser General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+// * Mozilla Public License as published by the Mozilla Foundation, version 2.
+//
+// `piet-glow` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License or the Mozilla Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License and the Mozilla
+// Public License along with `piet-glow`. If not, see <https://www.gnu.org/licenses/>.
+
+//! An example with a basic usage of the library.
+
+include!("util/setup_context.rs");
+
+use piet::{RenderContext as _, Text, TextLayoutBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut layout = None;
+    let mut last_width = 0;
+
+    util::with_renderer(move |render_context, width, _height| {
+        render_context.clear(None, piet::Color::WHITE);
+
+        let layout = if layout.is_none() || width != last_width {
+            layout.insert({
+                render_context
+                    .text()
+                    .new_text_layout(TEXT)
+                    .max_width(width as f64)
+                    .text_color(piet::Color::rgb(0.1, 0.1, 0.1))
+                    .build()
+                    .expect("failed to build text layout")
+            })
+        } else {
+            layout.as_mut().unwrap()
+        };
+        last_width = width;
+
+        render_context.draw_text(layout, (10.0, 10.0));
+    })
+}
+
+const TEXT: &str = "the quick fox jumps over the lazy dog
+1234567890~-=+{};:'<>?
+ThE QuicK fox Jumps Over The laZy d0g
+قبل هو أمدها مشارف ارتكبها, فصل لم زهاء التقليدي. الى ثم ديسمبر 
+経だルぴぞ月職カオ宣清こぼトそ積7旬タウ社改オ案処がやく途国地
+❤️💀🔥😊";

--- a/crates/piet-glow/examples/text.rs
+++ b/crates/piet-glow/examples/text.rs
@@ -47,9 +47,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
 }
 
-const TEXT: &str = "the quick fox jumps over the lazy dog
+const TEXT: &str = "the quick brown fox jumps over the lazy dog
 1234567890~-=+{};:'<>?
-ThE QuicK fox Jumps Over The laZy d0g
+ThE QuicK brown fox Jumps Over The laZy d0g
 قبل هو أمدها مشارف ارتكبها, فصل لم زهاء التقليدي. الى ثم ديسمبر 
 経だルぴぞ月職カオ宣清こぼトそ積7旬タウ社改オ案処がやく途国地
 ❤️💀🔥😊";

--- a/crates/piet-hardware/Cargo.toml
+++ b/crates/piet-hardware/Cargo.toml
@@ -12,11 +12,10 @@ categories = ["rendering::graphics-api"]
 description = "Toolkit for creating GPU accelerated 2D graphics applications"
 
 [dependencies]
-ab_glyph = "0.2.20"
 ahash = { version = "0.8.3", default-features = false, features = ["std"] }
 arrayvec = "0.7.2"
 bytemuck = { version = "1.13.0", default-features = false, features = ["derive"] }
-cosmic-text = { version = "0.8.0", default-features = false }
+cosmic-text = { version = "0.8.0", default-features = false, features = ["swash"] }
 etagere = "0.2.7"
 hashbrown = { version = "0.13.2", default-features = false }
 lyon_tessellation = "1.0.10"

--- a/crates/piet-hardware/src/atlas.rs
+++ b/crates/piet-hardware/src/atlas.rs
@@ -155,7 +155,7 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
                 })?;
 
                 let bounds = outline.px_bounds();
-                let (width, height) = (bounds.width() as i32, bounds.height() as i32);
+                let (width, height) = (bounds.width().ceil() as i32, bounds.height().ceil() as i32);
                 let mut buffer = vec![0u32; (width * height) as usize];
 
                 // Draw the glyph.

--- a/crates/piet-hardware/src/atlas.rs
+++ b/crates/piet-hardware/src/atlas.rs
@@ -146,8 +146,13 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
                 // A: ab_glyph already exists in the winit dep tree, which this crate is intended
                 //    to be used with.
                 let font_ref = ab_glyph::FontRef::try_from_slice(font_data.data()).piet_err()?;
-                let glyph_id = ab_glyph::GlyphId(glyph.cache_key.glyph_id)
-                    .with_scale(f32::from_bits(glyph.cache_key.font_size_bits));
+                let glyph_id = ab_glyph::GlyphId(glyph.cache_key.glyph_id).with_scale_and_position(
+                    f32::from_bits(glyph.cache_key.font_size_bits),
+                    (
+                        glyph.cache_key.x_bin.as_float(),
+                        glyph.cache_key.y_bin.as_float(),
+                    ),
+                );
                 let outline = font_ref.outline_glyph(glyph_id).ok_or_else(|| {
                     Pierror::BackendError({
                         format!("Failed to outline glyph {}", glyph.cache_key.glyph_id).into()

--- a/crates/piet-hardware/src/atlas.rs
+++ b/crates/piet-hardware/src/atlas.rs
@@ -26,7 +26,7 @@ use super::resources::Texture;
 use super::ResultExt;
 
 use ahash::RandomState;
-use cosmic_text::{CacheKey, LayoutGlyph};
+use cosmic_text::{CacheKey, FontSystem, LayoutGlyph, Placement, SwashCache, SwashContent};
 use etagere::{Allocation, AtlasAllocator};
 use hashbrown::hash_map::{Entry, HashMap};
 
@@ -48,6 +48,9 @@ pub(crate) struct Atlas<C: GpuContext + ?Sized> {
 
     /// The hash map between the glyphs used and the texture allocation.
     glyphs: HashMap<CacheKey, Position, RandomState>,
+
+    /// The cache for the swash layout.
+    swash_cache: SwashCache,
 }
 
 /// The data needed for rendering a glyph.
@@ -67,8 +70,8 @@ struct Position {
     /// The allocation of the glyph in the atlas.
     allocation: Allocation,
 
-    /// The rectangle of the glyph relative to the position.
-    rect: Rect,
+    /// Placement of the glyph.
+    placement: Placement,
 }
 
 impl<C: GpuContext + ?Sized> Atlas<C> {
@@ -90,6 +93,7 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
             size: (max_width, max_height),
             allocator: AtlasAllocator::new([max_width as i32, max_height as i32].into()),
             glyphs: HashMap::with_hasher(RandomState::new()),
+            swash_cache: SwashCache::new(),
         })
     }
 
@@ -104,15 +108,15 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
     pub(crate) fn uv_rect(
         &mut self,
         glyph: &LayoutGlyph,
-        font_data: &cosmic_text::Font,
+        font_system: &mut FontSystem,
     ) -> Result<GlyphData, Pierror> {
         let alloc_to_rect = {
             let (width, height) = self.size;
             move |posn: &Position| {
                 let alloc = &posn.allocation;
 
-                let max_x = alloc.rectangle.min.x + posn.rect.width() as i32;
-                let max_y = alloc.rectangle.min.y + posn.rect.height() as i32;
+                let max_x = alloc.rectangle.min.x + posn.placement.width as i32;
+                let max_y = alloc.rectangle.min.y + posn.placement.height as i32;
 
                 let uv_rect = Rect::new(
                     alloc.rectangle.min.x as f64 / width as f64,
@@ -120,13 +124,13 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
                     max_x as f64 / width as f64,
                     max_y as f64 / height as f64,
                 );
-                let offset = posn.rect.origin();
-                let size = posn.rect.size();
+                let offset = (posn.placement.left as f64, posn.placement.top as f64);
+                let size = (posn.placement.width as f64, posn.placement.height as f64);
 
                 GlyphData {
                     uv_rect,
-                    size,
-                    offset,
+                    size: size.into(),
+                    offset: offset.into(),
                 }
             }
         };
@@ -140,54 +144,53 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
             }
 
             Entry::Vacant(v) => {
-                use ab_glyph::Font as _;
+                // Get the swash image.
+                let sw_image = self
+                    .swash_cache
+                    .get_image_uncached(font_system, glyph.cache_key)
+                    .ok_or_else(|| {
+                        Pierror::BackendError({
+                            format!("Failed to outline glyph {}", glyph.cache_key.glyph_id).into()
+                        })
+                    })?;
 
-                // Q: Why are we using ab_glyph instead of swash, which cosmic-text uses?
-                // A: ab_glyph already exists in the winit dep tree, which this crate is intended
-                //    to be used with.
-                let font_ref = ab_glyph::FontRef::try_from_slice(font_data.data()).piet_err()?;
-                let glyph_id = ab_glyph::GlyphId(glyph.cache_key.glyph_id).with_scale_and_position(
-                    f32::from_bits(glyph.cache_key.font_size_bits),
-                    (
-                        glyph.cache_key.x_bin.as_float(),
-                        glyph.cache_key.y_bin.as_float(),
-                    ),
-                );
-                let outline = font_ref.outline_glyph(glyph_id).ok_or_else(|| {
-                    Pierror::BackendError({
-                        format!("Failed to outline glyph {}", glyph.cache_key.glyph_id).into()
-                    })
-                })?;
+                // Render it to a buffer.
+                let mut buffer = vec![
+                    0u32;
+                    sw_image.placement.width as usize
+                        * sw_image.placement.height as usize
+                ];
+                match sw_image.content {
+                    SwashContent::Color => {
+                        // Copy the color to the buffer.
+                        buffer
+                            .iter_mut()
+                            .zip(sw_image.data.chunks(4))
+                            .for_each(|(buf, input)| {
+                                let color =
+                                    u32::from_ne_bytes([input[0], input[1], input[2], input[3]]);
+                                *buf = color;
+                            });
+                    }
+                    SwashContent::Mask => {
+                        // Copy the mask to the buffer.
+                        buffer
+                            .iter_mut()
+                            .zip(sw_image.data.iter())
+                            .for_each(|(buf, input)| {
+                                let color = u32::from_ne_bytes([255, 255, 255, *input]);
+                                *buf = color;
+                            });
+                    }
+                    _ => return Err(Pierror::NotSupported),
+                }
 
-                let bounds = outline.px_bounds();
-                let (width, height) = (bounds.width().ceil() as i32, bounds.height().ceil() as i32);
-                let mut buffer = vec![0u32; (width * height) as usize];
-
-                // Draw the glyph.
-                outline.draw(|x, y, c| {
-                    let pixel = {
-                        let pixel_offset = (x + y * width as u32) as usize;
-
-                        match buffer.get_mut(pixel_offset) {
-                            Some(pixel) => pixel,
-                            None => return,
-                        }
-                    };
-
-                    // Convert the color to a u32.
-                    let color = {
-                        let cbyte = (255.0 * c) as u8;
-                        u32::from_ne_bytes([cbyte, cbyte, cbyte, cbyte])
-                    };
-
-                    // Set the pixel.
-                    *pixel = color;
-                });
+                let (width, height) = (sw_image.placement.width, sw_image.placement.height);
 
                 // Find a place for it in the texture.
                 let alloc = self
                     .allocator
-                    .allocate([width, height].into())
+                    .allocate([width as i32, height as i32].into())
                     .ok_or_else(|| {
                         Pierror::BackendError("Failed to allocate glyph in texture atlas.".into())
                     })?;
@@ -195,7 +198,7 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
                 // Insert the glyph into the texture.
                 self.texture.write_subtexture(
                     (alloc.rectangle.min.x as u32, alloc.rectangle.min.y as u32),
-                    (width as u32, height as u32),
+                    (width, height),
                     piet::ImageFormat::RgbaPremul,
                     bytemuck::cast_slice::<_, u8>(&buffer),
                 );
@@ -203,12 +206,7 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
                 // Insert the allocation into the map.
                 let alloc = v.insert(Position {
                     allocation: alloc,
-                    rect: Rect::new(
-                        bounds.min.x as f64,
-                        bounds.min.y as f64,
-                        bounds.max.x as f64,
-                        bounds.max.y as f64,
-                    ),
+                    placement: sw_image.placement,
                 });
 
                 // Return the UV rectangle.

--- a/crates/piet-hardware/src/lib.rs
+++ b/crates/piet-hardware/src/lib.rs
@@ -481,15 +481,11 @@ impl<C: GpuContext + ?Sized> piet::RenderContext for RenderContext<'_, C> {
                 let atlas = restore.atlas.as_mut().unwrap();
                 |(glyph, line_y)| {
                     // Get the rectangle in texture space representing the glyph.
-                    let font_data = text.with_font_system_mut(|fs| {
-                        fs.get_font(glyph.cache_key.font_id)
-                            .expect("font not found")
-                    });
                     let GlyphData {
                         uv_rect,
                         offset,
                         size,
-                    } = match atlas.uv_rect(glyph, &font_data) {
+                    } = match text.with_font_system_mut(|fs| atlas.uv_rect(glyph, fs)) {
                         Ok(rect) => rect,
                         Err(e) => {
                             tracing::trace!("failed to get uv rect: {}", e);
@@ -501,7 +497,7 @@ impl<C: GpuContext + ?Sized> piet::RenderContext for RenderContext<'_, C> {
                     let pos_rect = Rect::from_origin_size(
                         (
                             glyph.x_int as f64 + pos.x + offset.x,
-                            glyph.y_int as f64 + line_y + pos.y + offset.y,
+                            glyph.y_int as f64 + line_y + pos.y - offset.y,
                         ),
                         size,
                     );

--- a/crates/piet-hardware/src/lib.rs
+++ b/crates/piet-hardware/src/lib.rs
@@ -501,8 +501,13 @@ impl<C: GpuContext + ?Sized> piet::RenderContext for RenderContext<'_, C> {
                         // Get the rectangle in screen space representing the glyph.
                         let pos_rect = Rect::from_origin_size(
                             (
-                                glyph.x_int as f64 + pos.x + offset.x,
-                                glyph.y_int as f64 + line_y + pos.y + offset.y,
+                                glyph.x_int as f64
+                                    + pos.x
+                                    + offset.x,
+                                glyph.y_int as f64
+                                    + line_y
+                                    + pos.y
+                                    + offset.y,
                             ),
                             size,
                         );
@@ -512,7 +517,7 @@ impl<C: GpuContext + ?Sized> piet::RenderContext for RenderContext<'_, C> {
                                 let [r, g, b, a] = [color.r(), color.g(), color.b(), color.a()];
                                 piet::Color::rgba8(r, g, b, a)
                             }
-                            None => piet::Color::WHITE,
+                            None => piet::util::DEFAULT_TEXT_COLOR
                         };
 
                         Some(TessRect {

--- a/crates/piet-hardware/src/rasterizer.rs
+++ b/crates/piet-hardware/src/rasterizer.rs
@@ -200,6 +200,7 @@ impl Rasterizer {
 }
 
 /// A rectangle to be tessellated.
+#[derive(Clone)]
 pub(crate) struct TessRect {
     /// The rectangle to be tessellated.
     pub(crate) pos: Rect,


### PR DESCRIPTION
This PR makes it so this crate uses `swash` for text rendering instead of `ab_glyph`, which seems to create a much more sane text layout.