### PR TITLE
Use robust buffers to avoid unsafe code

### DIFF
--- a/crates/piet-hardware/examples/gl.rs
+++ b/crates/piet-hardware/examples/gl.rs
@@ -836,7 +836,7 @@ impl piet_hardware::GpuContext for GlContext {
         }
     }
 
-    unsafe fn write_vertices(
+    fn write_vertices(
         &self,
         buffer: &Self::VertexBuffer,
         vertices: &[piet_hardware::Vertex],

--- a/crates/piet-hardware/src/gpu_backend.rs
+++ b/crates/piet-hardware/src/gpu_backend.rs
@@ -88,15 +88,9 @@ pub trait GpuContext {
 
     /// Write vertices to a vertex buffer.
     ///
-    /// # Safety
-    ///
-    /// The indices must be valid for the given vertices.
-    unsafe fn write_vertices(
-        &self,
-        buffer: &Self::VertexBuffer,
-        vertices: &[Vertex],
-        indices: &[u32],
-    );
+    /// The indices must be valid for the vertices set; however, it is up to the GPU implementation
+    /// to actually check this.
+    fn write_vertices(&self, buffer: &Self::VertexBuffer, vertices: &[Vertex], indices: &[u32]);
 
     /// Push buffer data to the GPU.
     fn push_buffers(

--- a/crates/piet-hardware/src/lib.rs
+++ b/crates/piet-hardware/src/lib.rs
@@ -41,6 +41,8 @@
 //! This crate works first and foremost by converting drawing operations to a series of
 //! triangles.
 
+#![forbid(unsafe_code, rust_2018_idioms)]
+
 pub use piet;
 
 use lyon_tessellation::FillRule;
@@ -228,8 +230,7 @@ impl<C: GpuContext + ?Sized> RenderContext<'_, C> {
         self.source.buffers.rasterizer.fill_rects(rects);
 
         // Push the buffers to the GPU.
-        // SAFETY: The indices are valid.
-        unsafe { self.push_buffers(texture) }
+        self.push_buffers(texture)
     }
 
     /// Fill in the provided shape.
@@ -248,8 +249,7 @@ impl<C: GpuContext + ?Sized> RenderContext<'_, C> {
             })?;
 
         // Push the incoming buffers.
-        // SAFETY: The indices are valid.
-        unsafe { self.push_buffers(brush.texture(self.size).as_ref().map(|t| t.texture())) }
+        self.push_buffers(brush.texture(self.size).as_ref().map(|t| t.texture()))
     }
 
     fn stroke_impl(
@@ -271,12 +271,11 @@ impl<C: GpuContext + ?Sized> RenderContext<'_, C> {
         )?;
 
         // Push the incoming buffers.
-        // SAFETY: Buffer indices do not exceed the size of the vertex buffer.
-        unsafe { self.push_buffers(brush.texture(self.size).as_ref().map(|t| t.texture())) }
+        self.push_buffers(brush.texture(self.size).as_ref().map(|t| t.texture()))
     }
 
     /// Push the values currently in the renderer to the GPU.
-    unsafe fn push_buffers(&mut self, texture: Option<&Texture<C>>) -> Result<(), Pierror> {
+    fn push_buffers(&mut self, texture: Option<&Texture<C>>) -> Result<(), Pierror> {
         // Upload the vertex and index buffers.
         self.source.buffers.vbo.upload(
             self.source.buffers.rasterizer.vertices(),

--- a/crates/piet-hardware/src/resources.rs
+++ b/crates/piet-hardware/src/resources.rs
@@ -193,7 +193,7 @@ impl<C: GpuContext + ?Sized> VertexBuffer<C> {
         Ok(Self::from_raw(context, resource))
     }
 
-    pub(crate) unsafe fn upload(&self, data: &[Vertex], indices: &[u32]) {
+    pub(crate) fn upload(&self, data: &[Vertex], indices: &[u32]) {
         self.context.write_vertices(self.resource(), data, indices)
     }
 }

--- a/crates/piet-wgpu/src/context.rs
+++ b/crates/piet-wgpu/src/context.rs
@@ -493,7 +493,7 @@ impl<DaQ: DeviceAndQueue + ?Sized> piet_hardware::GpuContext for GpuContext<DaQ>
         drop(buffer);
     }
 
-    unsafe fn write_vertices(
+    fn write_vertices(
         &self,
         buffer: &Self::VertexBuffer,
         vertices: &[piet_hardware::Vertex],

--- a/crates/piet-wgpu/src/lib.rs
+++ b/crates/piet-wgpu/src/lib.rs
@@ -24,6 +24,8 @@
 //! [`piet`]: https://crates.io/crates/piet
 //! [`wgpu`]: https://crates.io/crates/wgpu
 
+#![forbid(unsafe_code, rust_2018_idioms)]
+
 use std::borrow;
 
 use piet_hardware::piet::kurbo::Affine;


### PR DESCRIPTION
This is a breaking change in `piet-hardware`.