### PR TITLE
Add support for copying area of the surface into an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This log describes changes in the `piet-hardware`, `piet-glow` and `piet-wgpu` crates.
 
+## piet-glow UNRELEASED
+
+- Update to the newest `piet-hardware` version.
+
+## piet-wgpu UNRELEASED
+
+- Update to the newest `piet-hardware` version.
+
+## piet-hardware UNRELEASED
+
+- **Breaking:** Add the `capture_area` method for capturing an area of the screen.
+- Add support for dashed lines.
+- Fix some minor bugs.
+
 ## piet-wgpu 0.2.2
 
 - Set default texture color space to non-SRGB.

--- a/crates/piet-glow/examples/test_picture.rs
+++ b/crates/piet-glow/examples/test_picture.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let context = guard.as_mut().unwrap();
 
                         // Uses unimplemented bits.
-                        if [12, 16].contains(&number) {
+                        if number == 12 {
                             return Ok(());
                         }
 

--- a/crates/piet-hardware/src/atlas.rs
+++ b/crates/piet-hardware/src/atlas.rs
@@ -182,7 +182,10 @@ impl<C: GpuContext + ?Sized> Atlas<C> {
                                 *buf = color;
                             });
                     }
-                    _ => return Err(Pierror::NotSupported),
+                    content => {
+                        tracing::warn!("Unsupported swash content: {:?}", content);
+                        return Err(Pierror::NotSupported);
+                    }
                 }
 
                 let (width, height) = (sw_image.placement.width, sw_image.placement.height);

--- a/crates/piet-hardware/src/gpu_backend.rs
+++ b/crates/piet-hardware/src/gpu_backend.rs
@@ -92,6 +92,14 @@ pub trait GpuContext {
     /// to actually check this.
     fn write_vertices(&self, buffer: &Self::VertexBuffer, vertices: &[Vertex], indices: &[u32]);
 
+    /// Capture an area from the screen and put it into a texture.
+    fn capture_area(
+        &self,
+        texture: &Self::Texture,
+        offset: (u32, u32),
+        size: (u32, u32),
+    ) -> Result<(), Self::Error>;
+
     /// Push buffer data to the GPU.
     fn push_buffers(
         &self,

--- a/crates/piet-wgpu/src/buffer.rs
+++ b/crates/piet-wgpu/src/buffer.rs
@@ -20,6 +20,14 @@
 // Public License along with `piet-hardware`. If not, see <https://www.gnu.org/licenses/>.
 
 //! A wrapper around the WGPU buffers.
+//!
+//! You might notice that we use a scheme where we set up a chain of buffers and make sure writes
+//! don't overlap, rather than just using one buffer. Don't worry, this is normal! Since buffer
+//! writes are asynchronous, we need to make sure that we don't write to the same buffer while
+//! it's still being used by the GPU. Therefore we use extra buffers to make sure that we don't
+//! step on any toes.
+//!
+//! This system is far from elegant. Any suggestions for improvement are welcome!
 
 use super::{DeviceAndQueue, GpuContext};
 use piet_hardware::Vertex;

--- a/crates/piet-wgpu/src/context.rs
+++ b/crates/piet-wgpu/src/context.rs
@@ -27,7 +27,7 @@ use super::DeviceAndQueue;
 
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::hash_map::{Entry, HashMap};
-use std::convert::Infallible;
+use std::fmt;
 use std::mem;
 use std::num::NonZeroU64;
 use std::rc::Rc;
@@ -143,6 +143,17 @@ struct Uniforms {
 }
 
 type UniformBytes = [u8; mem::size_of::<Uniforms>()];
+
+#[derive(Debug)]
+pub(crate) struct NotYetSupported;
+
+impl fmt::Display for NotYetSupported {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "not yet supported")
+    }
+}
+
+impl std::error::Error for NotYetSupported {}
 
 impl<DaQ: DeviceAndQueue + ?Sized> GpuContext<DaQ> {
     /// Create a new GPU context.
@@ -318,7 +329,7 @@ impl<DaQ: DeviceAndQueue + ?Sized> GpuContext<DaQ> {
 impl<DaQ: DeviceAndQueue + ?Sized> piet_hardware::GpuContext for GpuContext<DaQ> {
     type Texture = WgpuTexture;
     type VertexBuffer = WgpuVertexBuffer;
-    type Error = Infallible;
+    type Error = NotYetSupported;
 
     fn clear(&self, color: piet_hardware::piet::Color) {
         // Set the inner clear color.
@@ -473,6 +484,16 @@ impl<DaQ: DeviceAndQueue + ?Sized> piet_hardware::GpuContext for GpuContext<DaQ>
         texture
             .borrow_mut()
             .set_texture_interpolation(self, interpolation)
+    }
+
+    fn capture_area(
+        &self,
+        _texture: &Self::Texture,
+        _offset: (u32, u32),
+        _size: (u32, u32),
+    ) -> Result<(), Self::Error> {
+        // TODO: This is hard on wgpu! Look into this later.
+        Err(NotYetSupported)
     }
 
     fn max_texture_size(&self) -> (u32, u32) {


### PR DESCRIPTION
- [x] Tested on all platforms affected by this change
- [x] Signed the [Contribution License Agreement (CLA)](https://cla-assistant.io/notgull/piet-hardware)

Not supported yet for `wgpu`.