### PR TITLE
Use kurbo for dashed lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
 ]
 
 resolver = "2"
+
+[patch.crates-io]
+kurbo = { git = "https://github.com/linebender/kurbo.git", branch = "stroke" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-kurbo = { git = "https://github.com/linebender/kurbo.git", branch = "stroke" }
+kurbo = { git = "https://github.com/linebender/kurbo.git" }

--- a/crates/piet-hardware/src/brush.rs
+++ b/crates/piet-hardware/src/brush.rs
@@ -85,11 +85,15 @@ impl<C: GpuContext + ?Sized> Brush<C> {
         )
         .piet_err()?;
 
-        let bounds = Rect::from_points(gradient.start, gradient.end);
+        let mut bounds = Rect::from_points(gradient.start, gradient.end);
         let offset = -bounds.origin().to_vec2();
 
-        if approx_eq(bounds.width(), 0.0) || approx_eq(bounds.height(), 0.0) {
-            return Err(Pierror::InvalidInput);
+        if approx_eq(bounds.width(), 0.0) {
+            bounds.x1 += 1.0;
+        }
+
+        if approx_eq(bounds.height(), 0.0) {
+            bounds.y1 += 1.0;
         }
 
         texture.write_linear_gradient(context, device, queue, &gradient, bounds.size(), offset)?;

--- a/crates/piet-hardware/src/lib.rs
+++ b/crates/piet-hardware/src/lib.rs
@@ -288,6 +288,10 @@ impl<C: GpuContext + ?Sized> RenderContext<'_, '_, '_, C> {
                 let pos = vert.position();
                 brush.make_vertex(pos.into())
             },
+            |vert| {
+                let pos = vert.position();
+                brush.make_vertex(pos.into())
+            },
         )?;
 
         // Push the incoming buffers.
@@ -645,7 +649,7 @@ impl<C: GpuContext + ?Sized> piet::RenderContext for RenderContext<'_, '_, '_, C
 
     fn transform(&mut self, transform: Affine) {
         let slot = &mut self.state.last_mut().unwrap().transform;
-        *slot = transform * *slot;
+        *slot *= transform;
     }
 
     fn make_image(

--- a/crates/piet-hardware/src/rasterizer.rs
+++ b/crates/piet-hardware/src/rasterizer.rs
@@ -176,11 +176,7 @@ impl Rasterizer {
                     stroke.with_miter_limit(limit).with_join(kurbo::Join::Miter)
                 }
             };
-
-            let mut dashes = vec![];
-            dashes.extend(style.dash_pattern.iter().copied());
-
-            stroke = stroke.with_dashes(style.dash_offset, dashes);
+            stroke = stroke.with_dashes(style.dash_offset, style.dash_pattern.iter().copied());
 
             // Stroke out and fill it.
             let filled_path = kurbo::stroke(shape.path_elements(tolerance), &stroke, tolerance);

--- a/crates/piet-hardware/src/rasterizer.rs
+++ b/crates/piet-hardware/src/rasterizer.rs
@@ -182,7 +182,8 @@ impl Rasterizer {
             opts = opts.opt_level(kurbo::StrokeOptLevel::Subdivide);
 
             // Stroke out and fill it.
-            let filled_path = kurbo::stroke(shape.path_elements(tolerance), &stroke, &opts, tolerance); 
+            let filled_path =
+                kurbo::stroke(shape.path_elements(tolerance), &stroke, &opts, tolerance);
 
             return self.fill_shape(filled_path, FillRule::NonZero, tolerance, cvt_fill_vertex);
         }

--- a/crates/piet-hardware/src/rasterizer.rs
+++ b/crates/piet-hardware/src/rasterizer.rs
@@ -178,8 +178,11 @@ impl Rasterizer {
             };
             stroke = stroke.with_dashes(style.dash_offset, style.dash_pattern.iter().copied());
 
+            let mut opts = kurbo::StrokeOpts::default();
+            opts = opts.opt_level(kurbo::StrokeOptLevel::Subdivide);
+
             // Stroke out and fill it.
-            let filled_path = kurbo::stroke(shape.path_elements(tolerance), &stroke, tolerance);
+            let filled_path = kurbo::stroke(shape.path_elements(tolerance), &stroke, &opts, tolerance); 
 
             return self.fill_shape(filled_path, FillRule::NonZero, tolerance, cvt_fill_vertex);
         }

--- a/crates/piet-hardware/src/resources.rs
+++ b/crates/piet-hardware/src/resources.rs
@@ -103,8 +103,8 @@ impl<C: GpuContext + ?Sized> Texture<C> {
         offset: Vec2,
     ) -> Result<(), Pierror> {
         let shader = tiny_skia::RadialGradient::new(
+            convert_to_ts_point(gradient.center + gradient.origin_offset),
             convert_to_ts_point(gradient.center),
-            convert_to_ts_point(gradient.center - gradient.origin_offset),
             gradient.radius as f32,
             gradient
                 .stops


### PR DESCRIPTION
- [x] Tested on all platforms affected by this change
- [x] Signed the [Contribution License Agreement (CLA)](https://cla-assistant.io/notgull/piet-hardware)

Uses linebender/kurbo#286 to render dashed lines. Not perfect but good enough for government work.